### PR TITLE
feat: Enhance create-wrapped script to fetch Custom ERC-20 Token ID and support native tokens  

### DIFF
--- a/src/scripts/create-wrapped.ts
+++ b/src/scripts/create-wrapped.ts
@@ -17,7 +17,7 @@ import { getSigner } from '../helpers/helpers';
 	const destChain = wh.getChain('Sepolia');
 
 	// Retrieve the token ID(for ERC-20)from the source chain
-	const erc20TokenAddress = '0xdCCa3C38b5e25f0907E93a01BeBFc91aAfE2387b'; // Custom ERC-20 Token Address
+	const erc20TokenAddress = 'CUSTOM ERC_20TOKENADDRESS'; // Custom ERC-20 Token Address
     const erc20TokenId: TokenId = Wormhole.tokenId(origChain.chain, erc20TokenAddress);
     console.log('ERC20 Token ID for Avalanche Sepolia (Example):', erc20TokenId);
 
@@ -34,10 +34,7 @@ import { getSigner } from '../helpers/helpers';
 	// Check if the token is already wrapped on the destination chain
 	try {
 		const wrapped = await tbDest.getWrappedAsset(erc20TokenId);
-		console.log("🚀 ~ create-wrapped.ts:35 ~ wrapped:", wrapped)
-
 		console.log(`Token already wrapped on ${destChain.chain}. Skipping attestation.`);
-
 
 		return { chain: destChain.chain, address: wrapped };
 	} catch (e) {
@@ -67,7 +64,6 @@ import { getSigner } from '../helpers/helpers';
 	// Fetch the signed VAA
 	const timeout = 25 * 60 * 1000;
 	const vaa = await wh.getVaa(msgs[0]!, 'TokenBridge:AttestMeta', timeout);
-	console.log("🚀 ~ create-wrapped.ts:42 ~ vaa:", vaa)
 
 	if (!vaa) {
 		throw new Error('VAA not found after retries exhausted. Try extending the timeout.');
@@ -82,8 +78,6 @@ import { getSigner } from '../helpers/helpers';
 		vaa,
 		Wormhole.parseAddress(destSigner.chain(), destSigner.address())
 	);
-	console.log("🚀 ~ create-wrapped.ts:34 ~ subAttestation:", subAttestation)
-
 
 	// Send attestation transaction and log the transaction hash
 	const tsx = await signSendWait(destChain, subAttestation, destSigner);

--- a/src/scripts/create-wrapped.ts
+++ b/src/scripts/create-wrapped.ts
@@ -1,14 +1,13 @@
-import { ChainContext, Wormhole, signSendWait, wormhole, TokenId } from '@wormhole-foundation/sdk';
+import { Wormhole, signSendWait, wormhole, TokenId } from '@wormhole-foundation/sdk';
 import evm from '@wormhole-foundation/sdk/evm';
-// import solana from '@wormhole-foundation/sdk/solana';
-// import sui from '@wormhole-foundation/sdk/sui';
+import solana from '@wormhole-foundation/sdk/solana';
+import sui from '@wormhole-foundation/sdk/sui';
 import { inspect } from 'util';
 import { getSigner } from '../helpers/helpers';
 
 (async function () {
-	const wh = await wormhole('Testnet', [evm]);
+	const wh = await wormhole('Testnet', [evm, solana, sui]);
 	console.log("🚀 ~ create-wrapped.ts:10 ~ wh:", wh)
-
 
 	// Define the source and destination chains
 	const origChain = wh.getChain('Avalanche');
@@ -17,13 +16,12 @@ import { getSigner } from '../helpers/helpers';
 	const destChain = wh.getChain('Sepolia');
 
 	// Retrieve the token ID(for ERC-20)from the source chain
-	const erc20TokenAddress = '0xdCCa3C38b5e25f0907E93a01BeBFc91aAfE2387b'; // Custom ERC-20 Token Address
+	const erc20TokenAddress = 'Custom ERC-20ADDRESS'; // Custom ERC-20 Token Address
     const erc20TokenId: TokenId = Wormhole.tokenId(origChain.chain, erc20TokenAddress);
     console.log('ERC20 Token ID for Avalanche Sepolia (Example):', erc20TokenId);
 
 	// Retrieve the token ID(for native)from the source chain
 	// const token = await origChain.getNativeWrappedTokenId();
-	// console.log("🚀 ~ create-wrapped.ts:20 ~ token:", token)
 
 	// Destination chain signer setup
 	const gasLimit = BigInt(2_500_000); // Optional for EVM Chains

--- a/src/scripts/create-wrapped.ts
+++ b/src/scripts/create-wrapped.ts
@@ -17,7 +17,7 @@ import { getSigner } from '../helpers/helpers';
 	const destChain = wh.getChain('Sepolia');
 
 	// Retrieve the token ID(for ERC-20)from the source chain
-	const erc20TokenAddress = 'CUSTOM ERC_20TOKENADDRESS'; // Custom ERC-20 Token Address
+	const erc20TokenAddress = '0xdCCa3C38b5e25f0907E93a01BeBFc91aAfE2387b'; // Custom ERC-20 Token Address
     const erc20TokenId: TokenId = Wormhole.tokenId(origChain.chain, erc20TokenAddress);
     console.log('ERC20 Token ID for Avalanche Sepolia (Example):', erc20TokenId);
 


### PR DESCRIPTION
- Enhanced the create-wrapped script to fetch the Custom ERC-20 Token ID , enabling the creation of a wrapped version of any Custom ERC-20 token.
 
- For native token support, developers can uncomment the native-specific code block to enable functionality tailored for native tokens.
 
This update ensures flexibility and broadens the utility of the script, supporting both ERC-20 and native token wrapping seamlessly.